### PR TITLE
Avoid crash when executed without command-line arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+CMakeCache.txt
+CMakeFiles/
+Makefile
+cmake_install.cmake
+external/efsw/CMakeFiles/
+external/efsw/cmake_install.cmake
+external/efsw/libefsw.a
+liblua.a
+luafiles.c
+viewer
+vpv

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -461,7 +461,8 @@ void Window::displaySettings()
 
     ImGui::SliderInt("Index", &index, 0, sequences.size()-1);
     ImGui::SameLine(); ImGui::ShowHelpMarker("Choose which sequence to display in the window (space / backspace)");
-    index = (index + sequences.size()) % sequences.size();
+    if (sequences.size() > 0)
+        this->index = (this->index + sequences.size()) % sequences.size();
 }
 
 void Window::postRender()


### PR DESCRIPTION
- The program crashes because of a division by zero if executed without command-line arguments when exploring the Window menu.
- Added a .gitignore.