### PR TITLE
Refactor the Shader class

### DIFF
--- a/external/imgui/examples/sdl_opengl3_example/imgui_impl_sdl_gl3.cpp
+++ b/external/imgui/examples/sdl_opengl3_example/imgui_impl_sdl_gl3.cpp
@@ -86,7 +86,7 @@ static int          g_AttribLocationTex = 0, g_AttribLocationProjMtx = 0;
 static int          g_AttribLocationPosition = 0, g_AttribLocationUV = 0, g_AttribLocationColor = 0;
 static unsigned int g_VboHandle = 0,g_ElementsHandle = 0;
 
-Shader* g_shader;
+Shader::Program * g_shader;
 
 // This is the main rendering function that you have to implement and provide to ImGui (via setting up 'RenderDrawListsFn' in the ImGuiIO structure)
 // Note that this implementation is little overcomplicated because we are saving/setting up/restoring every OpenGL state explicitly, in order to be able to run within any OpenGL engine that doesn't do so. 
@@ -371,10 +371,9 @@ bool ImGui_ImplSdlGL3_CreateDeviceObjects()
         "	out_color = f_color * texture(tex, f_texcoord.st);\n"
         "}\n";
 
-    g_shader = new Shader(vertex_shader, fragment_shader);
-    g_shader->compile();
+    g_shader = new Shader::Program({Shader::Vertex(vertex_shader), Shader::Fragment(fragment_shader)});
     GLDEBUG();
-    g_ShaderHandle = g_shader->getProgram();
+    g_ShaderHandle = g_shader->getProgramID();
 
     g_AttribLocationTex = glGetUniformLocation(g_ShaderHandle, "tex");
     g_AttribLocationProjMtx = glGetUniformLocation(g_ShaderHandle, "v_transform");

--- a/external/imgui/examples/sdl_opengl3_example/imgui_impl_sdl_gl3.cpp
+++ b/external/imgui/examples/sdl_opengl3_example/imgui_impl_sdl_gl3.cpp
@@ -374,7 +374,7 @@ bool ImGui_ImplSdlGL3_CreateDeviceObjects()
     g_shader = new Shader(vertex_shader, fragment_shader);
     g_shader->compile();
     GLDEBUG();
-    g_ShaderHandle = g_shader->program;
+    g_ShaderHandle = g_shader->getProgram();
 
     g_AttribLocationTex = glGetUniformLocation(g_ShaderHandle, "tex");
     g_AttribLocationProjMtx = glGetUniformLocation(g_ShaderHandle, "v_transform");

--- a/src/Colormap.cpp
+++ b/src/Colormap.cpp
@@ -131,7 +131,7 @@ const std::string& Colormap::getShaderName() const
 
 bool Colormap::setShader(const std::string& name)
 {
-    Shader* s = getShader(name);
+    Shader::Program* s = getShader(name);
     if (s) {
         shader = s;
     }

--- a/src/Colormap.cpp
+++ b/src/Colormap.cpp
@@ -36,7 +36,7 @@ void Colormap::displaySettings()
 
     std::vector<const char*> items(gShaders.size());
     for (int i = 0; i < gShaders.size(); i++)
-        items[i] = gShaders[i]->name.c_str();
+        items[i] = gShaders[i]->getName().c_str();
     int index = 0;
     while (shader != gShaders[index]) index++;
     ImGui::Combo("Tonemap", &index, &items[0], gShaders.size());
@@ -126,7 +126,7 @@ void Colormap::previousShader()
 
 const std::string& Colormap::getShaderName() const
 {
-    return shader->name;
+    return shader->getName();
 }
 
 bool Colormap::setShader(const std::string& name)

--- a/src/Colormap.hpp
+++ b/src/Colormap.hpp
@@ -5,7 +5,7 @@
 
 #include "Image.hpp"  // for bands
 
-struct Shader;
+class Shader;
 
 struct Colormap
 {

--- a/src/Colormap.hpp
+++ b/src/Colormap.hpp
@@ -4,15 +4,14 @@
 #include <array>
 
 #include "Image.hpp"  // for bands
-
-class Shader;
+#include "Shader.hpp"
 
 struct Colormap
 {
     std::string ID;
     std::array<float,3> center;
     float radius;
-    Shader* shader;
+    Shader::Program* shader;
     bool initialized;
     int currentSat;
     BandIndices bands;

--- a/src/DisplayArea.cpp
+++ b/src/DisplayArea.cpp
@@ -26,7 +26,7 @@ static std::string checkerboardFragment = S(
 void DisplayArea::draw(const std::shared_ptr<Image>& image, ImVec2 pos, ImVec2 winSize,
                        const Colormap* colormap, const View* view, float factor)
 {
-    static Shader* checkerboard = createShader(checkerboardFragment);
+    static Shader::Program* checkerboard = createShader(checkerboardFragment);
 
     // update the texture if we have an image
     if (image) {

--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -102,7 +102,9 @@ void Shader::bind()
     GLDEBUG();
     glUseProgram(program);
     GLint loc = glGetUniformLocation(program, "tex");
-    glUniform1i(loc, 0);
+    if (loc >= 0) {
+        glUniform1i(loc, 0);
+    }
     GLDEBUG();
 }
 

--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -99,7 +99,7 @@ void Shader::setParameter(const std::string& name, float a, float b, float c)
     GLDEBUG();
 }
 
-unsigned int Shader::getProgram() const
+GLuint Shader::getProgram() const
 {
     return program;
 }

--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -24,6 +24,8 @@ get_or_insert_with(M &map, Key const& key, F functor)
     return value;
 }
 
+constexpr auto VERTEX_HEADER = "#version 330 core\n#ifdef GL_ES\nprecision mediump float;\n#endif\n";
+
 Shader::Shader(const std::string &vertex, const std::string &fragment, const std::string &name) :
     name(name), codeVertex(vertex), codeFragment(fragment), _uniform_locations()
 {
@@ -46,8 +48,7 @@ bool Shader::compile()
     GLint result;
     int infoLogLength;
 
-    std::string header = "#version 330 core\n#ifdef GL_ES\nprecision mediump float;\n#endif\n";
-    std::string headedCodeVertex = header + codeVertex;
+    std::string headedCodeVertex = VERTEX_HEADER + codeVertex;
     const char* codeVertexPtr = headedCodeVertex.c_str();
     GLuint vertexShader = glCreateShader(GL_VERTEX_SHADER);
     glShaderSource(vertexShader, 1, &codeVertexPtr, nullptr);
@@ -65,7 +66,7 @@ bool Shader::compile()
         }
     }
 
-    std::string headedCodeFragment = header + codeFragment;
+    std::string headedCodeFragment = VERTEX_HEADER + codeFragment;
     const char* codeFragmentPtr = headedCodeFragment.c_str();
     GLuint fragmentShader = glCreateShader(GL_FRAGMENT_SHADER);
     glShaderSource(fragmentShader, 1, &codeFragmentPtr, nullptr);

--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -8,8 +8,8 @@
 #include "Shader.hpp"
 #include "OpenGLDebug.hpp"
 
-Shader::Shader(const std::string &vertex, const std::string &fragment) :
-    codeVertex(vertex), codeFragment(fragment)
+Shader::Shader(const std::string &vertex, const std::string &fragment, const std::string &name) :
+    name(name), codeVertex(vertex), codeFragment(fragment)
 {
     static int id = 0;
     id++;
@@ -99,3 +99,12 @@ void Shader::setParameter(const std::string& name, float a, float b, float c)
     GLDEBUG();
 }
 
+unsigned int Shader::getProgram() const
+{
+    return program;
+}
+
+const std::string& Shader::getName() const
+{
+    return name;
+}

--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -101,7 +101,7 @@ void Shader::bind()
 {
     GLDEBUG();
     glUseProgram(program);
-    GLuint loc = glGetUniformLocation(program, "tex");
+    GLint loc = glGetUniformLocation(program, "tex");
     glUniform1i(loc, 0);
     GLDEBUG();
 }

--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -1,5 +1,6 @@
 #include <string>
 #include <vector>
+#include <utility>
 
 #include <GL/gl3w.h>
 #include "globals.hpp"
@@ -24,95 +25,123 @@ get_or_insert_with(M &map, Key const& key, F functor)
     return value;
 }
 
-constexpr auto VERTEX_HEADER = "#version 330 core\n#ifdef GL_ES\nprecision mediump float;\n#endif\n";
+namespace Shader {
 
-Shader::Shader(const std::string &vertex, const std::string &fragment, const std::string &name) :
-    name(name), codeVertex(vertex), codeFragment(fragment), _uniform_locations()
+constexpr auto GLSL_HEADER = "#version 330 core\n#ifdef GL_ES\nprecision mediump float;\n#endif\n";
+
+Shader::Shader(Type type, const std::string &code) :
+    _shader_id(glCreateShader(static_cast<GLenum>(type)))
 {
     static int id = 0;
     id++;
     ID = "Shader " + std::to_string(id);
+
+    if (_shader_id > 0) {
+        std::string header_and_code = GLSL_HEADER + code;
+        const char *codePtr = header_and_code.c_str();
+        glShaderSource(_shader_id, 1, &codePtr, nullptr);
+    }
 }
 
 Shader::~Shader()
 {
-    if (program) {
-        glDeleteProgram(program);
+    glDeleteShader(_shader_id);
+}
+
+Shader::Shader(Shader&& other) noexcept {
+    *this = std::move(other);
+}
+
+Shader& Shader::operator=(Shader&& other) noexcept {
+    if (this == &other) {
+        return *this;
     }
+
+    std::swap(_shader_id, other._shader_id);
+    ID = std::move(other.ID);
+    other._shader_id = 0;
+    return *this;
 }
 
 bool Shader::compile()
 {
-    GLDEBUG();
-
     GLint result;
-    int infoLogLength;
+    GLsizei infoLogLength;
 
-    std::string headedCodeVertex = VERTEX_HEADER + codeVertex;
-    const char* codeVertexPtr = headedCodeVertex.c_str();
-    GLuint vertexShader = glCreateShader(GL_VERTEX_SHADER);
-    glShaderSource(vertexShader, 1, &codeVertexPtr, nullptr);
-    glCompileShader(vertexShader);
+    GLDEBUG();
+    glCompileShader(_shader_id);
     GLDEBUG();
 
-    glGetShaderiv(vertexShader, GL_COMPILE_STATUS, &result);
+    glGetShaderiv(_shader_id, GL_COMPILE_STATUS, &result);
     if (result == GL_FALSE) {
-        glGetShaderiv(vertexShader, GL_INFO_LOG_LENGTH, &infoLogLength);
+        glGetShaderiv(_shader_id, GL_INFO_LOG_LENGTH, &infoLogLength);
         if (infoLogLength > 0) {
             std::vector<char> msg(infoLogLength+1);
-            glGetShaderInfoLog(vertexShader, infoLogLength, nullptr, &msg[0]);
+            glGetShaderInfoLog(_shader_id, infoLogLength, nullptr, &msg[0]);
             fprintf(stderr, "vertex: %s\n", &msg[0]);
             return false;
         }
     }
 
-    std::string headedCodeFragment = VERTEX_HEADER + codeFragment;
-    const char* codeFragmentPtr = headedCodeFragment.c_str();
-    GLuint fragmentShader = glCreateShader(GL_FRAGMENT_SHADER);
-    glShaderSource(fragmentShader, 1, &codeFragmentPtr, nullptr);
-    glCompileShader(fragmentShader);
-
-    glGetShaderiv(fragmentShader, GL_COMPILE_STATUS, &result);
-    if (result == GL_FALSE) {
-        glGetShaderiv(fragmentShader, GL_INFO_LOG_LENGTH, &infoLogLength);
-        if (infoLogLength > 0) {
-            std::vector<char> msg(infoLogLength+1);
-            glGetShaderInfoLog(fragmentShader, infoLogLength, nullptr, &msg[0]);
-            fprintf(stderr, "fragment: %s\n", &msg[0]);
-            return false;
-        }
-    }
-
-    program = glCreateProgram();
-    glAttachShader(program, vertexShader);
-    glAttachShader(program, fragmentShader);
-    glLinkProgram(program);
-
-    glDetachShader(program, vertexShader);
-    glDetachShader(program, fragmentShader);
-
-    glDeleteShader(vertexShader);
-    glDeleteShader(fragmentShader);
     GLDEBUG();
     return true;
 }
 
-void Shader::bind()
+Program::Program(std::initializer_list<Shader> shaders, std::string name) :
+    _program_id(glCreateProgram()), _uniform_locations(), _name(std::move(name))
 {
     GLDEBUG();
-    glUseProgram(program);
-    GLint loc = glGetUniformLocation(program, "tex");
+    for (const auto &shader : shaders) {
+        glAttachShader(_program_id, shader());
+    }
+
+    glLinkProgram(_program_id);
+
+    for (const auto &shader : shaders) {
+        glDetachShader(_program_id, shader());
+    }
+    GLDEBUG();
+}
+
+Program::Program(Program&& other) noexcept {
+    *this = std::move(other);
+}
+
+Program& Program::operator=(Program&& other) noexcept {
+    if (this == &other) {
+        return *this;
+    }
+
+    std::swap(_program_id, other._program_id);
+    _uniform_locations = std::move(other._uniform_locations);
+    _name = std::move(other._name);
+    other._program_id = 0;
+    return *this;
+}
+
+Program::~Program()
+{
+    if (_program_id > 0) {
+        glDeleteProgram(_program_id);
+    }
+}
+
+void Program::bind()
+{
+    GLDEBUG();
+    glUseProgram(_program_id);
+    GLint loc = glGetUniformLocation(_program_id, "tex");
     if (loc >= 0) {
         glUniform1i(loc, 0);
     }
     GLDEBUG();
 }
 
-void Shader::setParameter(const std::string& name, float a, float b, float c)
+void Program::setParameter(const std::string& name, float a, float b, float c)
 {
     GLDEBUG();
     auto insert_uniform_location = [this, &name](GLint &uniform_location){
-        uniform_location = glGetUniformLocation(program, name.c_str());
+        uniform_location = glGetUniformLocation(_program_id, name.c_str());
     };
     GLint uniform_location = get_or_insert_with(_uniform_locations, name, insert_uniform_location);
     if (uniform_location >= 0) {
@@ -121,12 +150,14 @@ void Shader::setParameter(const std::string& name, float a, float b, float c)
     GLDEBUG();
 }
 
-GLuint Shader::getProgram() const
+GLuint Program::getProgramID() const
 {
-    return program;
+    return _program_id;
 }
 
-const std::string& Shader::getName() const
+const std::string& Program::getName() const
 {
-    return name;
+    return _name;
+}
+
 }

--- a/src/Shader.hpp
+++ b/src/Shader.hpp
@@ -2,6 +2,8 @@
 
 #include <string>
 
+#include <GL/gl3w.h>
+
 class Shader {
 private:
     std::string ID;
@@ -10,7 +12,7 @@ private:
     std::string codeVertex;
     std::string codeFragment;
 
-    unsigned int program;
+    GLuint program;
 
 public:
     Shader(const std::string &vertex, const std::string &fragment, const std::string &name = "default");
@@ -21,7 +23,7 @@ public:
 
     void setParameter(const std::string& name, float a, float b, float c);
 
-    unsigned int getProgram() const;
+    GLuint getProgram() const;
     const std::string& getName() const;
 };
 

--- a/src/Shader.hpp
+++ b/src/Shader.hpp
@@ -1,38 +1,100 @@
 #pragma once
 
+#include <initializer_list>
 #include <map>
 #include <string>
 
 #include <GL/gl3w.h>
 
+
+// To create a shader use the following types:
+//
+//     Shader::Vertex vertex(code);
+//     Shader::Fragment fragment(code);
+//     ...
+//
+// To create a program:
+//
+//     Shader::Program program({
+//         Shader::Vertex(code),
+//         Shader::Fragment(code)
+//     });
+namespace Shader {
+enum class Type: GLenum {
+    Compute = GL_COMPUTE_SHADER,
+    Vertex = GL_VERTEX_SHADER,
+    TessControl = GL_TESS_CONTROL_SHADER,
+    TessEvaluation = GL_TESS_EVALUATION_SHADER,
+    Geometry = GL_GEOMETRY_SHADER,
+    Fragment = GL_FRAGMENT_SHADER
+};
+
+class Program;
+
 class Shader {
 private:
     std::string ID;
-    std::string name;
 
-    std::string codeVertex;
-    std::string codeFragment;
+    GLuint _shader_id;
 
-    GLuint program;
-
-    std::map<std::string, GLint> _uniform_locations;
+    GLuint operator()() const {
+        return _shader_id;
+    }
 
 public:
-    Shader(const std::string &vertex, const std::string &fragment, const std::string &name = "default");
+    Shader(Type type, const std::string &code);
     ~Shader();
 
-    // Since a Shader relies on an OpenGL `program`, it should not be copied.
+    // Since a Shader relies on an OpenGL shader resource, it should not be copied.
     // Otherwise, when one Shader (copied) is deleted, the other Shader will have its
-    // program deleted as well.
+    // shader resource deleted as well.
     Shader(const Shader &other) = delete;
     Shader& operator=(const Shader &other) = delete;
 
+    Shader(Shader&& other) noexcept;
+    Shader& operator=(Shader&& other) noexcept;
+
     bool compile();
-    void bind();
 
-    void setParameter(const std::string& name, float a, float b, float c);
-
-    GLuint getProgram() const;
-    const std::string& getName() const;
+    friend class Program;
 };
 
+template<Type type>
+class ShaderType : public Shader {
+public:
+    explicit ShaderType(const std::string &code) :
+        Shader(type, code)
+    {
+        compile();
+    }
+};
+
+using Vertex = ShaderType<Type::Vertex>;
+using Fragment = ShaderType<Type::Fragment>;
+
+class Program {
+public:
+    Program(std::initializer_list<Shader> shaders, std::string name = "<unnamed>");
+    ~Program();
+
+    // Since a ShaderProgram relies on an OpenGL `program`, it should not be copied.
+    // Otherwise, when one ShaderProgram (copied) is deleted, the other ShaderProgram will have its
+    // program deleted as well.
+    Program(const Program &other) = delete;
+    Program& operator=(const Program &other) = delete;
+
+    Program(Program&& other) noexcept;
+    Program& operator=(Program&& other) noexcept;
+
+    void bind();
+    void setParameter(const std::string& name, float a, float b, float c);
+    GLuint getProgramID() const;
+    const std::string& getName() const;
+
+private:
+    GLuint _program_id;
+    std::map<std::string, GLint> _uniform_locations;
+    std::string _name;
+};
+
+}

--- a/src/Shader.hpp
+++ b/src/Shader.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <string>
 
 #include <GL/gl3w.h>
@@ -13,6 +14,8 @@ private:
     std::string codeFragment;
 
     GLuint program;
+
+    std::map<std::string, GLint> _uniform_locations;
 
 public:
     Shader(const std::string &vertex, const std::string &fragment, const std::string &name = "default");

--- a/src/Shader.hpp
+++ b/src/Shader.hpp
@@ -2,14 +2,18 @@
 
 #include <string>
 
-struct Shader {
+class Shader {
+private:
     std::string ID;
     std::string name;
 
     std::string codeVertex;
     std::string codeFragment;
 
-    Shader(const std::string &vertex, const std::string &fragment);
+    unsigned int program;
+
+public:
+    Shader(const std::string &vertex, const std::string &fragment, const std::string &name = "default");
     ~Shader();
 
     bool compile();
@@ -17,7 +21,7 @@ struct Shader {
 
     void setParameter(const std::string& name, float a, float b, float c);
 
-    unsigned int program;
-private:
+    unsigned int getProgram() const;
+    const std::string& getName() const;
 };
 

--- a/src/Shader.hpp
+++ b/src/Shader.hpp
@@ -21,6 +21,12 @@ public:
     Shader(const std::string &vertex, const std::string &fragment, const std::string &name = "default");
     ~Shader();
 
+    // Since a Shader relies on an OpenGL `program`, it should not be copied.
+    // Otherwise, when one Shader (copied) is deleted, the other Shader will have its
+    // program deleted as well.
+    Shader(const Shader &other) = delete;
+    Shader& operator=(const Shader &other) = delete;
+
     bool compile();
     void bind();
 

--- a/src/globals.hpp
+++ b/src/globals.hpp
@@ -10,7 +10,6 @@ struct View;
 struct Player;
 struct Window;
 struct Colormap;
-class Shader;
 class Terminal;
 
 extern std::vector<Sequence*> gSequences;
@@ -18,7 +17,6 @@ extern std::vector<View*> gViews;
 extern std::vector<Player*> gPlayers;
 extern std::vector<Window*> gWindows;
 extern std::vector<Colormap*> gColormaps;
-extern std::vector<Shader*> gShaders;
 extern Terminal& gTerminal;
 
 extern bool gUseCache;

--- a/src/globals.hpp
+++ b/src/globals.hpp
@@ -10,7 +10,7 @@ struct View;
 struct Player;
 struct Window;
 struct Colormap;
-struct Shader;
+class Shader;
 class Terminal;
 
 extern std::vector<Sequence*> gSequences;

--- a/src/imgui_custom.cpp
+++ b/src/imgui_custom.cpp
@@ -8,7 +8,7 @@
 
 #include "events.hpp"
 
-extern Shader* g_shader;
+extern Shader::Program* g_shader;
 
 namespace ImGui {
 

--- a/src/imgui_custom.hpp
+++ b/src/imgui_custom.hpp
@@ -6,7 +6,7 @@
 namespace ImGui {
 
     struct ShaderUserData {
-        Shader* shader;
+        Shader::Program* shader;
         std::array<float, 3> scale;
         std::array<float, 3> bias;
     };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,7 +50,6 @@ std::vector<View*> gViews;
 std::vector<Player*> gPlayers;
 std::vector<Window*> gWindows;
 std::vector<Colormap*> gColormaps;
-std::vector<Shader*> gShaders;
 bool gSelecting;
 ImVec2 gSelectionFrom;
 ImVec2 gSelectionTo;

--- a/src/shaders.cpp
+++ b/src/shaders.cpp
@@ -7,6 +7,8 @@
 #include "shaders.hpp"
 #include "globals.hpp"
 
+std::vector<Shader*> gShaders;
+
 #define S(...) #__VA_ARGS__
 
 static std::string defaultVertex = S(

--- a/src/shaders.cpp
+++ b/src/shaders.cpp
@@ -24,9 +24,9 @@ static std::string defaultVertex = S(
     }
 );
 
-Shader* createShader(const std::string& mainFragment)
+Shader* createShader(const std::string& mainFragment, const std::string &name)
 {
-    Shader* shader = new Shader(defaultVertex, mainFragment);
+    Shader* shader = new Shader(defaultVertex, mainFragment, name);
     if (!shader->compile()) {
     }
     return shader;
@@ -34,12 +34,11 @@ Shader* createShader(const std::string& mainFragment)
 
 bool loadShader(const std::string& name, const std::string& mainFragment)
 {
-    Shader* shader = createShader(mainFragment);
-    shader->name = name;
+    Shader* shader = createShader(mainFragment, name);
     gShaders.push_back(shader);
     std::sort(gShaders.begin(), gShaders.end(),
               [](const Shader* lhs, const Shader* rhs) {
-                  return lhs->name < rhs->name;
+                  return lhs->getName() < rhs->getName();
               });
     return true;
 }
@@ -47,7 +46,7 @@ bool loadShader(const std::string& name, const std::string& mainFragment)
 Shader* getShader(const std::string& name)
 {
     for (auto s : gShaders) {
-        if (s->name == name)
+        if (s->getName() == name)
             return s;
     }
     return nullptr;

--- a/src/shaders.cpp
+++ b/src/shaders.cpp
@@ -7,11 +7,11 @@
 #include "shaders.hpp"
 #include "globals.hpp"
 
-std::vector<Shader*> gShaders;
+std::vector<Shader::Program*> gShaders;
 
 #define S(...) #__VA_ARGS__
 
-static std::string defaultVertex = S(
+static const std::string defaultVertex = S(
     uniform mat4 v_transform;
     layout(location=1) in vec2 v_position;
     layout(location=2) in vec2 v_texcoord;
@@ -26,26 +26,26 @@ static std::string defaultVertex = S(
     }
 );
 
-Shader* createShader(const std::string& mainFragment, const std::string &name)
+Shader::Program* createShader(const std::string& mainFragment, const std::string &name)
 {
-    Shader* shader = new Shader(defaultVertex, mainFragment, name);
-    if (!shader->compile()) {
-    }
-    return shader;
+    return new Shader::Program({
+                    Shader::Vertex(defaultVertex),
+                    Shader::Fragment(mainFragment)
+               }, name);
 }
 
 bool loadShader(const std::string& name, const std::string& mainFragment)
 {
-    Shader* shader = createShader(mainFragment, name);
+    Shader::Program* shader = createShader(mainFragment, name);
     gShaders.push_back(shader);
     std::sort(gShaders.begin(), gShaders.end(),
-              [](const Shader* lhs, const Shader* rhs) {
+              [](const Shader::Program* lhs, const Shader::Program* rhs) {
                   return lhs->getName() < rhs->getName();
               });
     return true;
 }
 
-Shader* getShader(const std::string& name)
+Shader::Program* getShader(const std::string& name)
 {
     for (auto s : gShaders) {
         if (s->getName() == name)

--- a/src/shaders.hpp
+++ b/src/shaders.hpp
@@ -3,11 +3,11 @@
 #include <string>
 #include <vector>
 
-class Shader;
+#include "Shader.hpp"
 
-extern std::vector<Shader*> gShaders;
+extern std::vector<Shader::Program *> gShaders;
 
-Shader* createShader(const std::string& tonemap, const std::string &name = "default");
+Shader::Program* createShader(const std::string& tonemap, const std::string &name = "<unnamed>");
 bool loadShader(const std::string& name, const std::string& tonemap);
-Shader* getShader(const std::string& name);
+Shader::Program* getShader(const std::string& name);
 

--- a/src/shaders.hpp
+++ b/src/shaders.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <string>
-#include <map>
+#include <vector>
 
 class Shader;
+
+extern std::vector<Shader*> gShaders;
 
 Shader* createShader(const std::string& tonemap, const std::string &name = "default");
 bool loadShader(const std::string& name, const std::string& tonemap);

--- a/src/shaders.hpp
+++ b/src/shaders.hpp
@@ -3,9 +3,9 @@
 #include <string>
 #include <map>
 
-struct Shader;
+class Shader;
 
-Shader* createShader(const std::string& tonemap);
+Shader* createShader(const std::string& tonemap, const std::string &name = "default");
 bool loadShader(const std::string& name, const std::string& tonemap);
 Shader* getShader(const std::string& name);
 


### PR DESCRIPTION
The Shader class contains only the Shader part. It creates a shader and
compiles it.
A template is present to simplify the construction of a shader.
   
    Shader::Vertex(code);
    
The Programm class builds a program, attach shaders, and link them.
Then, it detaches the shaders.
Program is built with a list of Shader as a parameter:
    
    new Shader::Program({
                    Shader::Vertex(code_vertex),
                    Shader::Fragment(code_fragment)
               });
    
Both Shader and Program cannot be copied (to avoid use after free), but
they implement move semantics (thus allowing the construction above).
    
They have been but in a namespace since they are all related to shaders,
and to avoid duplicating the name Shader everywhere in the class names.

The Program also has a cache of the uniforma locations to avoid calling glGetUniformLocation function.