### PR TITLE
update makefiles for all unix systems

### DIFF
--- a/external/iio/npy.c
+++ b/external/iio/npy.c
@@ -61,7 +61,7 @@ static size_t iio_type_size(int type)
 	case IIO_TYPE_DOUBLE: return sizeof(double);
 	case IIO_TYPE_LONGDOUBLE: return sizeof(long double);
 	case IIO_TYPE_HALF: return sizeof(float)/2;
-	default: fprintf(stderr, "unrecognized type %d", type);
+	default: return 0*fprintf(stderr, "unrecognized type %d", type);
 	}
 }
 

--- a/external/reproc/Makefile
+++ b/external/reproc/Makefile
@@ -1,0 +1,8 @@
+CPPFLAGS = -Ireproc/include -Ireproc++/include
+
+SRC      = $(shell ls reproc/src/*.c | grep -v windows)
+OBJ      = $(SRC:.c=.o) reproc++/src/reproc.o
+LIB      = reproc.a
+
+$(LIB)   : $(OBJ) ; $(AR) qc $(LIB) $(OBJ)
+clean    :        ; $(RM) $(LIB) $(OBJ)

--- a/misc/Makefile
+++ b/misc/Makefile
@@ -6,32 +6,48 @@ CPPFLAGS = -Iexternal/imgui -Iexternal/imgui-sfml -Iexternal/iio \
            -Iexternal/imscript -Iexternal/others -Iexternal/kaguya/include \
            -Iexternal/imgui/misc/fonts -Iexternal/imgui/examples/libs/gl3w \
            -Iexternal/imgui/examples/sdl_opengl3_example \
-           $(shell pkg-config --cflags gdal)
-CPPFLAGS += -DSDL -DUSE_GDAL -DGL3
-LDLIBS   = -lSDL2 -ljpeg -lpng -ltiff -lGL -lpthread -lz -ldl -lgdal
+           -Iexternal/doctest -Iexternal/ghc \
+           -Iexternal/reproc/reproc++/include
+CPPFLAGS += $(shell pkg-config sdl2 --cflags)
+#CPPFLAGS += -DDOCTEST_CONFIG_DISABLE
+CPPFLAGS += -DSDL -DGL3 -DVPV_VERSION=\"$(shell git describe --tags)\"
+LDLIBS   = -lSDL2 -ljpeg -lpng -ltiff -lpthread -lz -ldl
 
-SRC      = $(shell ls src/*.cpp)
+
+SRC      = $(shell ls src/*.cpp | grep -v tests)
 
 BIN      = vpv
-OBJ      = $(SRC:.cpp=.o) \
-           src/wrapplambda.o src/luafiles.o external/imgui/imgui.o \
+OBJ      = $(SRC:.cpp=.o) luafiles.o \
+           src/wrapplambda.o external/imgui/imgui.o \
            external/imgui/imgui_draw.o external/imgui/imgui_demo.o \
            external/iio/iio.o external/efsw/efsw.a external/lua/src/liblua.a \
            external/imgui/examples/sdl_opengl3_example/imgui_impl_sdl_gl3.o \
-           external/imgui/examples/libs/gl3w/GL/gl3w.o external/iio/npy.o
+           external/imgui/examples/libs/gl3w/GL/gl3w.o external/iio/npy.o \
+           external/reproc/reproc.a
 
 $(BIN)   : $(OBJ) ; $(CXX) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 clean    :
-	$(RM) $(BIN) $(OBJ) src/luafiles.c
+	$(RM) $(BIN) $(OBJ) luafiles.cpp
 	$(MAKE) -C external/efsw clean
+	$(MAKE) -C external/reproc clean
 	$(MAKE) -C external/lua/src clean
 
 external/efsw/efsw.a:      ; $(MAKE) -C external/efsw
+external/reproc/reproc.a:  ; $(MAKE) -C external/reproc
 external/lua/src/liblua.a:
 	$(MAKE) -C external/lua/src posix CC="$(CC)" MYCFLAGS="$(CFLAGS)"
 
-src/luafiles.c: vpvrc ; bash misc/genluafiles.sh $^ >$@
+luafiles.cpp: vpvrc ; bash misc/genluafiles.sh $^ >$@
 
 .deps.mk:         ; $(CXX) $(CPPFLAGS) -MM src/*.cpp |sed '/^[^ ]/s/^/src\//'>$@
 -include .deps.mk
+
+
+# hack around macOS shenanigans
+ifeq ($(shell uname),Darwin)
+CXXFLAGS += -std=c++17
+LDLIBS += -framework OpenGL -framework CoreFoundation -framework CoreServices
+else
+LDLIBS += -lGL
+endif

--- a/misc/Makefile
+++ b/misc/Makefile
@@ -40,7 +40,8 @@ external/lua/src/liblua.a:
 
 luafiles.cpp: vpvrc ; bash misc/genluafiles.sh $^ >$@
 
-.deps.mk:         ; $(CXX) $(CPPFLAGS) -MM src/*.cpp |sed '/^[^ ]/s/^/src\//'>$@
+.deps.mk:
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -MM src/*.cpp |sed '/^[^ ]/s/^/src\//'>$@
 -include .deps.mk
 
 

--- a/misc/Makefile.full
+++ b/misc/Makefile.full
@@ -1,0 +1,11 @@
+
+# include the base makefile
+include Makefile
+
+# enable gdal support
+CPPFLAGS += -DUSE_GDAL $(shell pkg-config --cflags gdal)
+LDLIBS   += -lgdal
+
+# enable octave support
+CPPFLAGS += -DUSE_OCTAVE $(shell pkg-config --cflags octave)
+LDLIBS   += $(shell pkg-config --libs octave) -loctinterp

--- a/misc/genluafiles.sh
+++ b/misc/genluafiles.sh
@@ -1,9 +1,8 @@
 
 cat <<EOF
-#include <stdio.h>
-#include <string.h>
-#include <lua.h>
-#include <lauxlib.h>
+#include <cstdio>
+#include <cstring>
+#include <lua.hpp>
 
 int load_luafiles(lua_State* L)
 {
@@ -13,12 +12,13 @@ EOF
 for f in $@; do
   FILE_CONTENT=`cat $f \
     | sed 's/"/\\\"/g' \
-    | sed ':a;N;$!ba;s/\n/\\\n/g'
+    | sed 's/^\(.*\)$/"\1\\\n"/'
   `
   cat <<EOF
   {
       const char* file = "$f";
-      const char* code = "${FILE_CONTENT}";
+      const char* code = ${FILE_CONTENT}
+      ;
       if (luaL_loadbuffer(L, code, strlen(code), file)) {
           fprintf(stderr, "%s", lua_tostring(L, -1));
           return 0;


### PR DESCRIPTION
These tiny makefiles replace the huge and ugly CmakeLists.txt on linux
and macOS.   Use "Makefile" for a bare-bones vpv, and "Makefile.full" for
octave and gdal support.

Edit the file "Makefile.full" in the obvious way to select each support individually.