### PR TITLE
Correct a typo in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ mkdir build
 cd build
 cmake ..
 make
-# change your PATH environnement variable so that the folder build/ is used
+# change your PATH environment variable so that the folder build/ is used
 # or install the binary 'vpv' system-wide using the following command:
 sudo make install
 ```


### PR DESCRIPTION
*environment* is already used in https://github.com/kidanger/vpv/blob/f5fe95e4e26c1073bc7aa7075e0b628e8eb31e1f/README.md?plain=1#L128

Verified exhaustiveness thanks to:

```bash
grep -ri environnement
```